### PR TITLE
Fix caching with mixed varg length.

### DIFF
--- a/src/nano-memoize.js
+++ b/src/nano-memoize.js
@@ -74,6 +74,7 @@
 				var l = maxargs||arguments.length,
 					i;
 				for(i=k.length-1;i>=0;i--) { // an array of arrays of args, each array represents a call signature
+					if (!maxargs && k[i].length !== l) continue; // cache miss if called with a different number of args
 					for(var j=l-1;j>=0 && eq(k[i][j],arguments[j]);j--) {	// compare each arg			
 						if(j===0) { return v[i]; } // the args matched
 					}

--- a/test/index.js
+++ b/test/index.js
@@ -91,6 +91,11 @@ describe("Test",function() {
 		result = multipleArg(arg1);
 		expect(result.arg1.arg).to.equal(1);
 	});
+	it("multiple varg mixed length",function() {
+		const res1 = varArg("multi1", "multi2");
+		const res2 = varArg("multi1");
+		expect(res1).to.not.equal(res2);
+	});
 	it("auto-detect vArg",function() {
 		const arg1 = 1, arg2 = 2;
 		expect(varArg.keyValues()).to.equal(null);


### PR DESCRIPTION
I'm using nano-memoize like this:

```javascript
const getStyle = nanoMemoize(function(...args) {
   ...
});

getStyle("color", "red")
=> { color: "red" } // cache miss, OK

getStyle("color", "red", "background", "white")
=> { color: "red", background: "white" } // cache miss, OK

getStyle("color", "red")
=> { color: "red", background: "white" } // cache hit, but the wrong cache!
```

This PR makes it so that `nano-memoize` only checks varg caches with the correct length, so that the second call to `getStyle("color", "red")` would return `{ color: "red" }` as expected.