### PR TITLE
support zero arg caching.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@
 			s = Object.create(null), // single arg function key/value cache
 			k = [], // multiple arg function arg key cache
 			v = [], // multiple arg function result cache
+			z, // index of zero arg result in v
 			wm = new WeakMap(),
 			d = function(key,c,k) { return setTimeout(function() {
 					if(k) { // dealing with multi-arg function, c and k are Arrays
@@ -73,6 +74,7 @@
 			f = (function() {
 				var l = maxargs||arguments.length,
 					i;
+				if (!l && z != null) return v[z];
 				for(i=k.length-1;i>=0;i--) { // an array of arrays of args, each array represents a call signature
 					if (!maxargs && k[i].length !== l) continue; // cache miss if called with a different number of args
 					for(var j=l-1;j>=0 && eq(k[i][j],arguments[j]);j--) {	// compare each arg			
@@ -80,6 +82,7 @@
 					}
 				}
 				i = k.length - (i + 1);
+				if (!l && z == null) z = i;
 				// set change timeout only when new value computed, hits will not push out the tte, but it is arguable they should not
 				return (!c||c(i,v,k)),v[i] = fn.apply(this,k[i] = arguments);
 			}).bind(this);

--- a/index.js
+++ b/index.js
@@ -92,7 +92,8 @@
 			wm = new WeakMap();
 			s = Object.create(null);
 			k = [];
-			v = []; 
+			v = [];
+			z = undefined;
 		};
 		f.keys = function() { return u ? null : k.slice(); };
 		f.values = function() { return u ? null : v.slice(); };

--- a/index.js
+++ b/index.js
@@ -72,9 +72,10 @@
 			// for multiple arg functions, loop through a cache of all the args
 			// looking at each arg separately so a test can abort as soon as possible
 			f = (function() {
-				var l = maxargs||arguments.length,
+				var al = arguments.length;
+				if (!al && z != null) return v[z];
+				var l = maxargs||al,
 					i;
-				if (!l && z != null) return v[z];
 				for(i=k.length-1;i>=0;i--) { // an array of arrays of args, each array represents a call signature
 					if (!maxargs && k[i].length !== l) continue; // cache miss if called with a different number of args
 					for(var j=l-1;j>=0 && eq(k[i][j],arguments[j]);j--) {	// compare each arg			
@@ -82,7 +83,7 @@
 					}
 				}
 				i = k.length - (i + 1);
-				if (!l && z == null) z = i;
+				if (!al && z == null) z = i;
 				// set change timeout only when new value computed, hits will not push out the tte, but it is arguable they should not
 				return (!c||c(i,v,k)),v[i] = fn.apply(this,k[i] = arguments);
 			}).bind(this);

--- a/src/nano-memoize.js
+++ b/src/nano-memoize.js
@@ -38,6 +38,7 @@
 			s = Object.create(null), // single arg function key/value cache
 			k = [], // multiple arg function arg key cache
 			v = [], // multiple arg function result cache
+			z, // index of zero arg result in v
 			wm = new WeakMap(),
 			d = function(key,c,k) { return setTimeout(function() {
 					if(k) { // dealing with multi-arg function, c and k are Arrays
@@ -73,6 +74,7 @@
 			f = (function() {
 				var l = maxargs||arguments.length,
 					i;
+				if (!l && z != null) return v[z];
 				for(i=k.length-1;i>=0;i--) { // an array of arrays of args, each array represents a call signature
 					if (!maxargs && k[i].length !== l) continue; // cache miss if called with a different number of args
 					for(var j=l-1;j>=0 && eq(k[i][j],arguments[j]);j--) {	// compare each arg			
@@ -80,6 +82,7 @@
 					}
 				}
 				i = k.length - (i + 1);
+				if (!l && z == null) z = i;
 				// set change timeout only when new value computed, hits will not push out the tte, but it is arguable they should not
 				return (!c||c(i,v,k)),v[i] = fn.apply(this,k[i] = arguments);
 			}).bind(this);

--- a/src/nano-memoize.js
+++ b/src/nano-memoize.js
@@ -92,7 +92,8 @@
 			wm = new WeakMap();
 			s = Object.create(null);
 			k = [];
-			v = []; 
+			v = [];
+			z = undefined;
 		};
 		f.keys = function() { return u ? null : k.slice(); };
 		f.values = function() { return u ? null : v.slice(); };

--- a/src/nano-memoize.js
+++ b/src/nano-memoize.js
@@ -72,9 +72,10 @@
 			// for multiple arg functions, loop through a cache of all the args
 			// looking at each arg separately so a test can abort as soon as possible
 			f = (function() {
-				var l = maxargs||arguments.length,
+				var al = arguments.length;
+				if (!al && z != null) return v[z];
+				var l = maxargs||al,
 					i;
-				if (!l && z != null) return v[z];
 				for(i=k.length-1;i>=0;i--) { // an array of arrays of args, each array represents a call signature
 					if (!maxargs && k[i].length !== l) continue; // cache miss if called with a different number of args
 					for(var j=l-1;j>=0 && eq(k[i][j],arguments[j]);j--) {	// compare each arg			
@@ -82,7 +83,7 @@
 					}
 				}
 				i = k.length - (i + 1);
-				if (!l && z == null) z = i;
+				if (!al && z == null) z = i;
 				// set change timeout only when new value computed, hits will not push out the tte, but it is arguable they should not
 				return (!c||c(i,v,k)),v[i] = fn.apply(this,k[i] = arguments);
 			}).bind(this);

--- a/test/index.js
+++ b/test/index.js
@@ -61,6 +61,11 @@ describe("Test",function() {
 		expect(result).to.equal(value);
 		expect(singleArg(value)).to.equal(value);
 	});
+	it("single undefined arg cached", function () {
+		const res1 = singleArg();
+		const res2 = singleArg(undefined);
+		expect(res1).to.equal(res2);
+	});
 	it("multiple arg primitive cached",function() {
 		const result = multipleArg(1,2);
 		expect(result.arg1).to.equal(1);
@@ -95,6 +100,13 @@ describe("Test",function() {
 	it("multiple varg mixed length",function() {
 		const res1 = varArg("multi1", "multi2");
 		const res2 = varArg("multi1");
+		expect(res1).to.not.equal(res2);
+	});
+	it("zero varg cached", function() {
+		const res1 = varArg();
+		const res2 = varArg("multi3");
+		const res3 = varArg();
+		expect(res1).to.equal(res3);
 		expect(res1).to.not.equal(res2);
 	});
 	it("callTimeout",function(done) {


### PR DESCRIPTION
Currently, executing a memoized function with no arguments keeps filling `k` with `{}` (`arguments`) items and `v` with results of each arg-less invocation, instead of caching. Basically a memory leak.

One would expect vArgs to work with 0 args, as well.