### PR TITLE
Exclude parcel-cache from git, will also exclude it from the package published on npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# Parcel cache
+.parcel-cache


### PR DESCRIPTION
Hello,

I saw that your package on NPM is 2.2MB, and was curious why, apparently the `.parcel-cache` is published along with your package : https://www.npmjs.com/package/nano-memoize?activeTab=code

This change will exclude it from the publish:

__Before__

```
npm notice === Tarball Details === 
npm notice name:          nano-memoize                            
npm notice version:       v3.0.8                                  
npm notice filename:      nano-memoize-v3.0.8.tgz                 
npm notice package size:  283.8 kB                                
npm notice unpacked size: 2.2 MB                                  
npm notice shasum:        b9b2fbf905cae4a83893e76101248b1fff9a5627
npm notice integrity:     sha512-gDFoWEu0BkRW3[...]sLouFpUt7uc5Q==
npm notice total files:   24  
```

__After__

```
npm notice === Tarball Details === 
npm notice name:          nano-memoize                            
npm notice version:       v3.0.8                                  
npm notice filename:      nano-memoize-v3.0.8.tgz                 
npm notice package size:  20.5 kB                                 
npm notice unpacked size: 90.8 kB                                 
npm notice shasum:        1c3850748579a3b8d9f134ed8dd55515c89bc9ac
npm notice integrity:     sha512-DEuAmktVCFRv4[...]rNCYrL3NBCgxQ==
npm notice total files:   17   
```