### PR TITLE
Remove empty 'engines' field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "source": "src/index.js",
   "main": "dist/nano-memoize.js",
   "module": "./index.js",
-  "engines": {},
   "sideEffects": false,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
I'm having some issues with this module where npm does not seem to properly install it (on a fresh repo, first npm install installs all dependencies, second install only re-installs nano-memoize, third install is fine and no changes). It's very odd and I suspect a npm bug triggered by something in this module.

So I was looking for odd package.json properties which could cause it and I've found this [`engines`](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#engines) property which makes no sense to define as empty object, so let's remove it.

See https://github.com/npm/cli/issues/6370 for the npm issue.