### PR TITLE
Remove 'v' prefix in package.json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-memoize",
-  "version": "v3.0.10",
+  "version": "3.0.10",
   "description": "Faster than fast, smaller than micro ... a nano speed and nano size memoizer.",
   "type:": "module",
   "source": "src/index.js",


### PR DESCRIPTION
It's not forbidden but very uncommon to have a `v` prefix in the `version` field. Remove it to avoid strange npm bugs like https://github.com/npm/cli/issues/6370.

Would appreciate a new publish after this bugfix.